### PR TITLE
Fixing "run" command output and adding ability to filter run by instance id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 plugins/*internal*.py
 plugins/*private*.py
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # CraftShell
 
 Framework for utility commands
+
+
+## Instructions
+
+Run 
+
+```
+pip install cmd2 boto3 pexpect
+```

--- a/README.md
+++ b/README.md
@@ -3,10 +3,23 @@
 Framework for utility commands
 
 
-## Instructions
+# Instructions
 
-Run 
+## Installation 
 
 ```
 pip install cmd2 boto3 pexpect
 ```
+
+## Run
+
+```
+python3 main.py
+```
+
+Then run:
+```
+> help
+```
+to explore
+

--- a/plugins/hyperpod_commands.py
+++ b/plugins/hyperpod_commands.py
@@ -810,11 +810,10 @@ class HyperPodCommands:
                 self.poutput("")
 
                 p = pexpect.spawn(*self.aws_config.awscli, ["ssm", "start-session", "--target", ssm_target])
-                p.expect(["\r\n.*sh-.*# ", "\r\n# "])
-                after = p.after.decode("utf-8")
-                if not after.endswith("\r\n# "):
-                    p.expect("sh-.*# ")
-                self.poutput(after, end="")
+                # For some reason on AL2 AMI (used by HyperPod+EKS), there are two shell prompts
+                # in the output after connecting so we account for that here with the very strange expected prompt
+                p.expect(["\r\n.*sh-.*# .*sh-.*#", "\r\n# "])
+                self.poutput(p.after.decode("utf-8"), end="")
                 p.sendline(args.command)
                 p.expect(["sh-.*# ", "# "])
                 self.poutput(p.before.decode("utf-8"),end="")

--- a/plugins/hyperpod_commands.py
+++ b/plugins/hyperpod_commands.py
@@ -811,11 +811,12 @@ class HyperPodCommands:
                 self.poutput(f"Running command in {node_id}")
                 self.poutput("")
 
-                p = pexpect.popen_spawn.PopenSpawn([*self.aws_config.awscli, "ssm", "start-session", "--target", ssm_target])
-                p.expect("#")
+                p = pexpect.spawn(*self.aws_config.awscli, ["ssm", "start-session", "--target", ssm_target])
+                p.expect("sh-.*#")
+                p.expect("sh-.*#") # not sure why this is needed, but it is. Guessing there is a newline char sent by spawn that we dont know about
                 self.poutput(p.after.decode("utf-8"),end="")
                 p.sendline(args.command)
-                p.expect("#")
+                p.expect("sh-.*#")
                 self.poutput(p.before.decode("utf-8"),end="")
                 p.kill(signal.SIGINT)
 

--- a/plugins/hyperpod_commands.py
+++ b/plugins/hyperpod_commands.py
@@ -774,12 +774,13 @@ class HyperPodCommands:
     # ---
 
     argparser = subparsers1.add_parser("run", help="Run single line command in all nodes of specified instance group")
-    argparser.add_argument("cluster_name", metavar="CLUSTER_NAME", action="store", choices_provider=choices_cluster_names, help="Name of cluster")
+    argparser.add_argument("--cluster-name", metavar="CLUSTER_NAME", action="store", choices_provider=choices_cluster_names, help="Name of cluster")
     argparser.add_argument("--instance-group-name", action="store", required=True, help="Instance group name")
     argparser.add_argument("--command", action="store", required=True, help="Single line of command to run")
+    argparser.add_argument("--instances", nargs="+", action="store", required=False, default=[], help="Instances to target")
 
-    @cmd2.with_category(CATEGORY)
-    @cmd2.with_argparser(argparser)
+    # @cmd2.with_category(CATEGORY)
+    # @cmd2.with_argparser(argparser)
     def _do_run(self, args):
 
         sagemaker_client = self.get_sagemaker_client()
@@ -802,6 +803,9 @@ class HyperPodCommands:
             if instance_group_name==args.instance_group_name:
 
                 node_id = node["InstanceId"]
+                if args.instances and node_id not in args.instances:
+                    print(f"Skipping {node_id}")
+                    continue
                 ssm_target = f"sagemaker-cluster:{cluster_id}_{instance_group_name}-{node_id}"
 
                 self.poutput(f"Running command in {node_id}")


### PR DESCRIPTION
Fixes:
- fix `run` command - seems the command was not configured with cmd2 correctly for some reason. Simplified by just making cluster an option arg instead of positional arg. 
- fix `run` command output display - previously was not showing the output of the terminal commands

Feature:
- add ability to specify list of instances to target when calling `run` command
- Add pip install instructions to readme